### PR TITLE
OC Anonymizer Update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ venv
 catone.spec
 build
 dist
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,20 +1,43 @@
-# OC Anyonymizer – remove sensitive Data from your config.plist
+# OC Anonymizer – remove sensitive Data from your config.plist
 
-The following script was created to censor sensitive fields in OpenCore's config.plist
+## About
+Python Script for removing sensitive Data from OpenCore's config.plist and reset some settings to default before sharing your Config/EFI folder online.
 
-The reason why I created it is that many EFI I find online contain sensitive fields such as SMBIOS data.
-With this script you won't have any prob at all
+## Features
 
-# Usage
+Changes the following Settings/Parameters in the **config.plist**:
 
-```bash
-$> python3 oc_anonymizer.py PATH_TO_CONFIG.plist
-```
+- **SMBIOS** data:
+	- Deletes `PlatformInfo/Generic/MLB`
+	- Deletes `PlatformInfo/Generic/ROM`
+	- Deletes `PlatformInfo/Generic/SystemSerialNumber`
+	- Deletes `PlatformInfo/Generic/SystemUUID`
+- **Security Settings**:
+	- `Misc/Security/ApECID` = `0`
+	- `Misc/Security/ScanPolicy` = `0`
+	- `Misc/Security/SecureBootModel` = `Disabled` &rarr; Disables Apple Secure Boot hardware model to avoid issues during Installation. Re-enable in Post-Install so System Updates work when using an SMBIOS of a Mac model with a T2 Security Chip.
+	- `Misc/Security/Vault` = `Optional` 
+- **Other Settings**:
+	- Sets `Misc/Boot/LauncherOption` to `Disabled` &rarr; To avoid changing Boot Menu entries on the target system
+	- Deletes custom entries from `Misc/BlessOverride`
+	- Deletes custom boot loader entries from `Misc/Entries`
+	- Sets `Misc/Debug/Target` to `3` (Default)
 
-It'll create `censored_config.plist` with the stripped sensitive data
+## Instructions
+- Install [**Python**](https://www.python.org/) if you haven't already
+- Download [**OC Anonymizer**](https://github.com/5T33Z0/OC-Anonymizer/archive/refs/heads/master.zip) and unpack it
+- Copy/move the **OC-Anonymizer-master** folder to your Desktop
+- Start Terminal
+- Enter:</br>
+`cd desktop/OC-Anonymizer-master`
+- Next, enter </br>`python3 oc_anonymizer.py PATH_TO_CONFIG.plist` (you can also drag and drop the config into the terminal)
+- Hit `ENTER`
 
-# Credits
+This will create a `censored_config.plist`in the oc_anonymizer folder with remove sensitive data and settings changed as described. 
 
-- [acidanthera](https://github.com/acidanthera) for [OpenCorePkg](https://github.com/acidanthera)
+## Credits and Resources
+
+- [Acidanthera](https://github.com/acidanthera) for [OpenCorePkg](https://github.com/acidanthera)
 - [1alessandro1](https://github.com/1alessandro1) for the initial idea
-- my self for trying to escape from my daemons while coding. appreciate that
+- [Dreamwhite](https://github.com/dreamwhite) for the original Python script
+- [Guide](https://github.com/5T33Z0/OC-Little-Translated/tree/main/M_EFI_Upload_Chklst) for removing sensitive data manually

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # OC Anonymizer – remove sensitive Data from your config.plist
 
 ## About
-Python Script for removing sensitive Data from OpenCore's config.plist and reset some settings to default before sharing your Config/EFI folder online.
+Python Script for removing sensitive Data from OpenCore's `config.plist` and reset some settings to default before sharing your Config/EFI folder online.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# OC Anyonymizer – remove sensitive Data from your config-plist
+# OC Anyonymizer – remove sensitive Data from your config.plist
 
 The following script was created to censor sensitive fields in OpenCore's config.plist
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![macOS](https://img.shields.io/badge/Supported_OC_build:-≥0.8.2-white.svg)
+
 # OC Anonymizer – remove sensitive Data from your config.plist
 
 ## About

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# OC Anyonymizer – remove sensitive Data from your OpenCore fonfig-plist
+# OC Anyonymizer – remove sensitive Data from your config-plist
 
 The following script was created to censor sensitive fields in OpenCore's config.plist
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # OC Anonymizer – remove sensitive Data from your config.plist
 
 ## About
-Python Script for removing sensitive Data from OpenCore's `config.plist` before sharing your Config/EFI folder online. It also changes some settings to default, such as: ScanPolicy, Custom Entries, LauncherOptions, etc. See details below. Basically it removes all those settings specific to your system and user preferences which may not be desireble to have on a different machine.
+Python Script for removing sensitive data from OpenCore's `config.plist` before sharing your Config/EFI folder online. It also changes some settings to default, such as: ScanPolicy, Custom Entries, LauncherOptions, etc. See details below. Basically, it removes all those settings specific to your system and user preferences which may not be desireble to have on a different machine.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Changes the following Settings/Parameters in the **config.plist**:
 
 ## Instructions
 - Install [**Python**](https://www.python.org/) if you haven't already
-- Download [**OC Anonymizer**](https://github.com/5T33Z0/OC-Anonymizer/archive/refs/heads/master.zip) and unpack it
+- Click on "Code" > "Download ZIP" and upack it.
 - Copy/move the **OC-Anonymizer-master** folder to your Desktop
 - Start Terminal
 - Enter:</br>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Catone, the OpenCore config.plist censor
+# OC Anyonymizer – remove sensitive Data from your OpenCore fonfig-plist
 
 The following script was created to censor sensitive fields in OpenCore's config.plist
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # OC Anonymizer – remove sensitive Data from your config.plist
 
 ## About
-Python Script for removing sensitive Data from OpenCore's `config.plist` and reset some settings to default before sharing your Config/EFI folder online.
+Python Script for removing sensitive Data from OpenCore's `config.plist` and reset some settings to default before sharing your Config/EFI folder online. Basically it removes all those settings specific to your system and user preferences which may not be desireble to have on a different machine, such as: ScanPolicy, Custom Entries, LauncherOptions, etc. See details below.
 
 ## Features
 
@@ -35,7 +35,7 @@ Changes the following Settings/Parameters in the **config.plist**:
 - Next, enter </br>`python3 oc_anonymizer.py PATH_TO_CONFIG.plist` (you can also drag and drop the config into the terminal)
 - Hit `ENTER`
 
-This will create a `censored_config.plist`in the oc_anonymizer folder with remove sensitive data and settings changed as described. 
+This will create a `censored_config.plist`in the oc_anonymizer folder without sensitive data and changed settings as described. 
 
 ## Credits and Resources
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # OC Anonymizer – remove sensitive Data from your config.plist
 
 ## About
-Python Script for removing sensitive Data from OpenCore's `config.plist` and reset some settings to default before sharing your Config/EFI folder online. Basically it removes all those settings specific to your system and user preferences which may not be desireble to have on a different machine, such as: ScanPolicy, Custom Entries, LauncherOptions, etc. See details below.
+Python Script for removing sensitive Data from OpenCore's `config.plist` before sharing your Config/EFI folder online. It also changes some settings to default, such as: ScanPolicy, Custom Entries, LauncherOptions, etc. See details below. Basically it removes all those settings specific to your system and user preferences which may not be desireble to have on a different machine.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Changes the following Settings/Parameters in the **config.plist**:
 	- Deletes custom entries from `Misc/BlessOverride`
 	- Deletes custom boot loader entries from `Misc/Entries`
 	- Sets `Misc/Debug/Target` to `3` (Default)
+	- `UEFI/APFS`: Changes `MinDate` and `MinVersion` to `-1` to maximize macOS compatibility
 
 ## Instructions
 - Install [**Python**](https://www.python.org/) if you haven't already

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ Python Script for removing sensitive data from OpenCore's `config.plist` before 
 
 Changes the following Settings/Parameters in the **config.plist**:
 
-- **SMBIOS** data:
-	- Deletes `PlatformInfo/Generic/MLB`
-	- Deletes `PlatformInfo/Generic/ROM`
-	- Deletes `PlatformInfo/Generic/SystemSerialNumber`
-	- Deletes `PlatformInfo/Generic/SystemUUID`
+- Anonymizes **SMBIOS** data in:
+	- `PlatformInfo/Generic/MLB`
+	- `PlatformInfo/Generic/ROM`
+	- `PlatformInfo/Generic/SystemSerialNumber`
+	- `PlatformInfo/Generic/SystemUUID`
 - **Security Settings**:
 	- `Misc/Security/ApECID` = `0`
 	- `Misc/Security/ScanPolicy` = `0`

--- a/oc_anonymizer.py
+++ b/oc_anonymizer.py
@@ -16,7 +16,6 @@ def load_plist() -> dict:
 class PlistStripper:
     def __init__(self):
         self.plist = load_plist()
-        print(self.plist['PlatformInfo']['Generic']['ROM'])
         self.reset_misc_boot()
         self.delete_misc_blessoverride()
         self.reset_misc_debug()
@@ -84,7 +83,6 @@ class PlistStripper:
                 print(f"Successfully exported anonymized config.plist to {os.path.realpath(f.name)}")
             except (Exception,):
                 print("An error occurred while trying to save the censored config.plist file!")
-
 
 if __name__ == '__main__':
     plist_stripper = PlistStripper()

--- a/oc_anonymizer.py
+++ b/oc_anonymizer.py
@@ -52,7 +52,7 @@ class PlistStripper:
             -> Misc/Security/ApECID to 0 to disallow using personalised Apple Secure Boot identifiers (unsupported from
                 Monterey and later)
             -> Misc/Security/ScanPolicy = 0 to allow OpenCore's operating system detection policy
-            -> Misc/Security/SecureBootModel = Disables Apple Secure Boot hardware model to avoid issues during Installation. Re-enable in Post-Install so System Updates work when using an SMBIOS of a Mac model with a T2 Security Chip.
+            -> Misc/Security/SecureBootModel = Disabled. Disables Apple Secure Boot hardware model to avoid issues during Installation. Re-enable in Post-Install so System Updates work when using an SMBIOS of a Mac model with a T2 Security Chip.
             -> Misc/Security/Vault = Optional to disable OpenCore's vaulting mechanism
         """
 

--- a/oc_anonymizer.py
+++ b/oc_anonymizer.py
@@ -81,7 +81,7 @@ class PlistStripper:
         with open('censored_config.plist', 'wb') as f:
             try:
                 plistlib.dump(self.plist, f)
-                print(f"Successfully exported censored config.plist in {os.path.realpath(f.name)}")
+                print(f"Successfully exported anonymized config.plist to {os.path.realpath(f.name)}")
             except (Exception,):
                 print("An error occurred while trying to save the censored config.plist file!")
 

--- a/oc_anonymizer.py
+++ b/oc_anonymizer.py
@@ -17,39 +17,51 @@ class PlistStripper:
     def __init__(self):
         self.plist = load_plist()
         print(self.plist['PlatformInfo']['Generic']['ROM'])
-        self.censor_misc_boot()
-        self.censor_misc_debug()
-        self.censor_misc_security()
-        self.censor_platforminfo_generic()
-        self.censor_uefi_apfs()
+        self.reset_misc_boot()
+        self.delete_misc_blessoverride()
+        self.reset_misc_debug()
+        self.delete_misc_entries()
+        self.reset_misc_security()
+        self.delete_platforminfo_generic()
+        self.disable_uefi_apfs()
         self.dump()
 
-    def censor_misc_boot(self) -> None:
+    def reset_misc_boot(self) -> None:
         """ Sets Misc/Boot/LauncherOption to Disabled to avoid registering the launcher option in the firmware
         preferences for persistence"""
 
         self.plist['Misc']['Boot']['LauncherOption'] = 'Disabled'
 
-    def censor_misc_debug(self) -> None:
+    def delete_misc_blessoverride(self) -> None:
+        """ Deletes custom BlessOverride entries from config.plist"""
+
+        self.plist['Misc']['BlessOverride'] = []
+
+    def reset_misc_debug(self) -> None:
         """ Sets Misc/Debug/Target to 3"""
 
         self.plist['Misc']['Debug']['Target'] = 3
 
-    def censor_misc_security(self) -> None:
+    def delete_misc_entries(self) -> None:
+        """ Deletes custom bootloader entries from config.plist"""
+
+        self.plist['Misc']['Entries'] = []
+
+    def reset_misc_security(self) -> None:
         """Sets
             -> Misc/Security/ApECID to 0 to disallow using personalised Apple Secure Boot identifiers (unsupported from
                 Monterey and later)
             -> Misc/Security/ScanPolicy = 0 to allow OpenCore's operating system detection policy
-            -> Misc/Security/SecureBootModel = Default to configure Apple Secure Boot hardware model
+            -> Misc/Security/SecureBootModel = Disables Apple Secure Boot hardware model to avoid issues during Installation. Re-enable in Post-Install so System Updates work when using an SMBIOS of a Mac model with a T2 Security Chip.
             -> Misc/Security/Vault = Optional to disable OpenCore's vaulting mechanism
         """
 
         self.plist['Misc']['Security']['ApECID'] = 0
         self.plist['Misc']['Security']['ScanPolicy'] = 0
-        self.plist['Misc']['Security']['SecureBootModel'] = 'Default'
+        self.plist['Misc']['Security']['SecureBootModel'] = 'Disabled'
         self.plist['Misc']['Security']['Vault'] = 'Optional'
 
-    def censor_platforminfo_generic(self) -> None:
+    def delete_platforminfo_generic(self) -> None:
         """Censors several SMBIOS identification fields"""
 
         self.plist['PlatformInfo']['Generic']['MLB'] = 'XX-CHANGE_ME-XX'
@@ -57,7 +69,7 @@ class PlistStripper:
         self.plist['PlatformInfo']['Generic']['SystemSerialNumber'] = 'XX-CHANGE_ME-XX'
         self.plist['PlatformInfo']['Generic']['SystemUUID'] = 'XX-CHANGE_ME-XX'
 
-    def censor_uefi_apfs(self) -> None:
+    def disable_uefi_apfs(self) -> None:
         """ Sets minimal allowed APFS driver date and version to permit any release date and version to load"""
 
         self.plist['UEFI']['APFS']['MinDate'] = -1


### PR DESCRIPTION
- New Readme
- Added deletion of Misc/Entries and Misc/BlessOverride
- Renamed some parameters in the py script
- Changed SecureBootModel to Disabled to avoid crashes during macOS installation