### PR TITLE
Added lite version and Resizable BAR

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Changes the following Settings/Parameters in the **config.plist**:
 	- `PlatformInfo/Generic/SystemUUID`
 - **Security Settings**:
 	- `Misc/Security/ApECID` = `0` &rarr; ApECID has to be generated in the target system itself!
-	- `Misc/Security/ScanPolicy` = `0` &rarr; So the system sarchs all available volumes and file systems.
+	- `Misc/Security/ScanPolicy` = `0` &rarr; So the system checks for all supported device types and file systems.
 	- `Misc/Security/SecureBootModel` = `Disabled` &rarr; :warning: Disables Apple Secure Boot hardware model to avoid issues during Installation. Re-enable it in Post-Install so System Updates work when using an SMBIOS of a Mac model with a T2 Security Chip!
 	- `Misc/Security/Vault` = `Optional` &rarr; Has to be created on the target system itself!
 - **Other Settings**:
@@ -45,7 +45,7 @@ The lite version of this script will only anonymize SMBIOS and change APFS setti
 
 ## Instructions
 - Install [**Python**](https://www.python.org/) if you haven't already
-- Click on "Code" > "Download ZIP" and upack it.
+- Click on "Code" > "Download ZIP" and unpack it.
 - Run Terminal
 - Enter:</br>
 `cd ~/Downloads/OC-Anonymizer-master`
@@ -57,7 +57,7 @@ This will create a `censored_config.plist`in the oc_anonymizer folder without se
 
 ## Issues
 
-If you encounter any issue, please file a bugreport [here](https://github.com/dreamwhite/bugtracker/issues/new?assignees=dreamwhite&labels=bug&template=generic.md&title=)
+If you encounter any issue, please file a bug report [here](https://github.com/dreamwhite/bugtracker/issues/new?assignees=dreamwhite&labels=bug&template=generic.md&title=)
 
 ## Credits and Resources
 

--- a/README.md
+++ b/README.md
@@ -31,18 +31,18 @@ Changes the following Settings/Parameters in the **config.plist**:
 	- `UEFI/APFS`:  Changes `MinDate` and `MinVersion` to `-1` to maximize macOS compatibility. Otherwise the APFS driver isn't loaded in macOS 10.15 or older so you won't see any entries of APFS drives in OpenCore's Boot Menu.
 
 ### Lite version
-The lite version of this script will only anonymize SMBIOS and change APFS settings:
+The lite version of this script will only anonymize SMBIOS and change 2 other settings:
 
 - Anonymizes entries in **PlatformInfo/Generic**:
 	- `PlatformInfo/Generic/MLB`
 	- `PlatformInfo/Generic/ROM`
 	- `PlatformInfo/Generic/SystemSerialNumber`
 	- `PlatformInfo/Generic/SystemUUID`
+- **Other Settings**:
+	- `Misc/Security/ScanPolicy` = `0` &rarr; So the system checks for all supported device types and file systems.
+	- 	`UEFI/APFS`: Changes `MinDate` and `MinVersion` to `-1` to maximize macOS compatibility. Otherwise the APFS driver isn't loaded in macOS 10.15 or older so you won't see any entries of APFS drives in OpenCore's Boot Menu. 
 
-- Changes **APFS** settings: 
-	- `UEFI/APFS`: Changes `MinDate` and `MinVersion` to `-1` to maximize macOS compatibility. Otherwise the APFS driver isn't loaded in macOS 10.15 or older so you won't see any entries of APFS drives in OpenCore's Boot Menu. 
-
-## Instructions
+## Usage
 - Install [**Python**](https://www.python.org/) if you haven't already
 - Click on "Code" > "Download ZIP" and unpack it.
 - Run Terminal

--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 # OC Anonymizer – remove sensitive data from your config.plist
 
 ## About
-Python Script for removing sensitive data from OpenCore's `config.plist`. Useful if you plan to share your Config/EFI online. Also resets some settings to default values used in sample.plist which should not be carried over to a differnt system. Check the feature list for more details.
+Python Script for removing sensitive data from OpenCore's `config.plist`. Useful if you plan to share your Config/EFI online.
 
 ## Features
+The script comes in two flavors: "full" and "lite" which provide different feature-sets (listed below).
 
 ### Full version
-
 Changes the following Settings/Parameters in the **config.plist**:
 
 - Removes MLB, ROM, Serials from **PlatformInfo/Generic**: 
@@ -31,7 +31,6 @@ Changes the following Settings/Parameters in the **config.plist**:
 	- `UEFI/APFS`:  Changes `MinDate` and `MinVersion` to `-1` to maximize macOS compatibility. Otherwise the APFS driver isn't loaded in macOS 10.15 or older so you won't see any entries of APFS drives in OpenCore's Boot Menu.
 
 ### Lite version
-
 The lite version of this script will only anonymize SMBIOS and change APFS settings:
 
 - Anonymizes entries in **PlatformInfo/Generic**:
@@ -53,14 +52,12 @@ The lite version of this script will only anonymize SMBIOS and change APFS setti
 - For running the Lite Version, enter </br>`python3 oc_anonymizer_lite.py PATH_TO_CONFIG.plist`
 - Hit `ENTER`
 
-This will create a `censored_config.plist`in the oc_anonymizer folder without sensitive data and changed settings as described. Rename the file to config.plist and place it in the EFI folder you want to share with the world.
+This will create a `censored_config.plist` in the oc_anonymizer folder without sensitive data and changed settings as described. Rename the file to config.plist and place it in the EFI folder you want to share with the world.
 
 ## Issues
-
 If you encounter any issue, please file a bug report [here](https://github.com/dreamwhite/bugtracker/issues/new?assignees=dreamwhite&labels=bug&template=generic.md&title=)
 
 ## Credits and Resources
-
 - [Acidanthera](https://github.com/acidanthera) for [OpenCorePkg](https://github.com/acidanthera)
 - [1alessandro1](https://github.com/1alessandro1) for the initial idea
 - [Dreamwhite](https://github.com/dreamwhite) for the original Python script

--- a/README.md
+++ b/README.md
@@ -50,10 +50,10 @@ The lite version of this script will only anonymize SMBIOS and change APFS setti
 - Enter:</br>
 `cd ~/Downloads/OC-Anonymizer-master`
 - Next, enter </br>`python3 oc_anonymizer_full.py PATH_TO_CONFIG.plist` (or drag and drop your config into the terminal window after ".py")
-- For running the Lite Version, enter enter </br>`python3 oc_anonymizer_lite.py PATH_TO_CONFIG.plist`
+- For running the Lite Version, enter </br>`python3 oc_anonymizer_lite.py PATH_TO_CONFIG.plist`
 - Hit `ENTER`
 
-This will create a `censored_config.plist`in the oc_anonymizer folder without sensitive data and changed settings as described. Rename the file to config.plist and place it in the EFI folder you want to share with the worl
+This will create a `censored_config.plist`in the oc_anonymizer folder without sensitive data and changed settings as described. Rename the file to config.plist and place it in the EFI folder you want to share with the world.
 
 ## Issues
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![macOS](https://img.shields.io/badge/Supported_OC_build:-≥0.8.2-white.svg)
+![macOS](https://img.shields.io/badge/Supported_OC_version:-0.8.2+-white.svg)
 
 # OC Anonymizer – remove sensitive data from your config.plist
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Changes the following Settings/Parameters in the **config.plist**:
 
 ### Lite version
 
-The lite version of this script will only anonymize SMBIOS and APFS settings:
+The lite version of this script will only anonymize SMBIOS and change APFS settings:
 
 - Anonymizes entries in **PlatformInfo/Generic**:
 	- `PlatformInfo/Generic/MLB`
@@ -43,14 +43,13 @@ The lite version of this script will only anonymize SMBIOS and APFS settings:
 - Changes **APFS** settings: 
 	- `UEFI/APFS`: Changes `MinDate` and `MinVersion` to `-1` to maximize macOS compatibility. Otherwise the APFS driver isn't loaded in macOS 10.15 or older so you won't see any entries of APFS drives in OpenCore's Boot Menu. 
 
-
 ## Instructions
 - Install [**Python**](https://www.python.org/) if you haven't already
 - Click on "Code" > "Download ZIP" and upack it.
 - Run Terminal
 - Enter:</br>
 `cd ~/Downloads/OC-Anonymizer-master`
-- Next, enter </br>`python3 oc_anonymizer_full.py PATH_TO_CONFIG.plist` (or drag and drop your config into the terminal window after "".py")
+- Next, enter </br>`python3 oc_anonymizer_full.py PATH_TO_CONFIG.plist` (or drag and drop your config into the terminal window after ".py")
 - For running the Lite Version, enter enter </br>`python3 oc_anonymizer_lite.py PATH_TO_CONFIG.plist`
 - Hit `ENTER`
 

--- a/README.md
+++ b/README.md
@@ -3,40 +3,58 @@
 # OC Anonymizer – remove sensitive data from your config.plist
 
 ## About
-Python Script for removing sensitive data from OpenCore's `config.plist`. Useful if you plan to share your Config/EFI online. Also resets some settings to default values which should not be carried over to a differnt system. Check the feature list for more details.
+Python Script for removing sensitive data from OpenCore's `config.plist`. Useful if you plan to share your Config/EFI online. Also resets some settings to default values used in sample.plist which should not be carried over to a differnt system. Check the feature list for more details.
 
 ## Features
 
+### Full version
+
 Changes the following Settings/Parameters in the **config.plist**:
 
-- Anonymizes **SMBIOS** data for:
+- Removes MLB, ROM, Serials from **PlatformInfo/Generic**: 
 	- `PlatformInfo/Generic/MLB`
 	- `PlatformInfo/Generic/ROM`
 	- `PlatformInfo/Generic/SystemSerialNumber`
 	- `PlatformInfo/Generic/SystemUUID`
 - **Security Settings**:
-	- `Misc/Security/ApECID` = `0`
-	- `Misc/Security/ScanPolicy` = `0`
-	- `Misc/Security/SecureBootModel` = `Disabled` &rarr; :warning: Disables Apple Secure Boot hardware model to avoid issues during Installation. Re-enable it in Post-Install so System Updates work when using an SMBIOS of a Mac model with a T2 Security Chip.
-	- `Misc/Security/Vault` = `Optional` 
+	- `Misc/Security/ApECID` = `0` &rarr; ApECID has to be generated in the target system itself!
+	- `Misc/Security/ScanPolicy` = `0` &rarr; So the system sarchs all available volumes and file systems.
+	- `Misc/Security/SecureBootModel` = `Disabled` &rarr; :warning: Disables Apple Secure Boot hardware model to avoid issues during Installation. Re-enable it in Post-Install so System Updates work when using an SMBIOS of a Mac model with a T2 Security Chip!
+	- `Misc/Security/Vault` = `Optional` &rarr; Has to be created on the target system itself!
 - **Other Settings**:
-	- Sets `Misc/Boot/LauncherOption` to `Disabled` &rarr; To avoid changing boot menu entries on the target system's Firmware/BIOS.
-	- Removes custom entries from `Misc/BlessOverride`
+	- Changes `Boter/Quirks/ResizeAppleGpuBars` to `-1` &rarr; Disables Resizable BAR in macOS. Just in case the next user's GPU doesn't support it or it is disabled in BIOS.
+	- Changes `UEFI/Quirks/ResizeGpuBars` to `-1` &rarr; Disables Resizable BAR in UEFI for the same reason.
+	- Changes `Misc/Boot/LauncherOption` to `Disabled` &rarr; To avoid changing boot menu entries on the target system's Firmware/BIOS.
+	- Removes custom entries from `Misc/BlessOverride` &rarr; These overrides have to be created on the target system.
 	- Removes custom boot loader entries from `Misc/Entries`
-	- Sets `Misc/Debug/Target` to `3` (Default)
-	- `UEFI/APFS`: Changes `MinDate` and `MinVersion` to `-1` to maximize macOS compatibility
+	- Changes `Misc/Debug/Target` to `3` (Default)
+	- `UEFI/APFS`:  Changes `MinDate` and `MinVersion` to `-1` to maximize macOS compatibility. Otherwise the APFS driver isn't loaded in macOS 10.15 or older so you won't see any entries of APFS drives in OpenCore's Boot Menu.
+
+### Lite version
+
+The lite version of this script will only anonymize SMBIOS and APFS settings:
+
+- Anonymizes entries in **PlatformInfo/Generic**:
+	- `PlatformInfo/Generic/MLB`
+	- `PlatformInfo/Generic/ROM`
+	- `PlatformInfo/Generic/SystemSerialNumber`
+	- `PlatformInfo/Generic/SystemUUID`
+
+- Changes **APFS** settings: 
+	- `UEFI/APFS`: Changes `MinDate` and `MinVersion` to `-1` to maximize macOS compatibility. Otherwise the APFS driver isn't loaded in macOS 10.15 or older so you won't see any entries of APFS drives in OpenCore's Boot Menu. 
+
 
 ## Instructions
 - Install [**Python**](https://www.python.org/) if you haven't already
 - Click on "Code" > "Download ZIP" and upack it.
-- Copy/move the **OC-Anonymizer-master** folder to your Desktop
-- Start Terminal
+- Run Terminal
 - Enter:</br>
-`cd desktop/OC-Anonymizer-master`
-- Next, enter </br>`python3 oc_anonymizer.py PATH_TO_CONFIG.plist` (you can also drag and drop the config into the terminal)
+`cd ~/Downloads/OC-Anonymizer-master`
+- Next, enter </br>`python3 oc_anonymizer_full.py PATH_TO_CONFIG.plist` (or drag and drop your config into the terminal window after "".py")
+- For running the Lite Version, enter enter </br>`python3 oc_anonymizer_lite.py PATH_TO_CONFIG.plist`
 - Hit `ENTER`
 
-This will create a `censored_config.plist`in the oc_anonymizer folder without sensitive data and changed settings as described. 
+This will create a `censored_config.plist`in the oc_anonymizer folder without sensitive data and changed settings as described. Rename the file to config.plist and place it in the EFI folder you want to share with the worl
 
 ## Issues
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Changes the following Settings/Parameters in the **config.plist**:
 	- `Misc/Security/SecureBootModel` = `Disabled` &rarr; :warning: Disables Apple Secure Boot hardware model to avoid issues during Installation. Re-enable it in Post-Install so System Updates work when using an SMBIOS of a Mac model with a T2 Security Chip!
 	- `Misc/Security/Vault` = `Optional` &rarr; Has to be created on the target system itself!
 - **Other Settings**:
-	- Changes `Boter/Quirks/ResizeAppleGpuBars` to `-1` &rarr; Disables Resizable BAR in macOS. Just in case the next user's GPU doesn't support it or it is disabled in BIOS.
+	- Changes `Booter/Quirks/ResizeAppleGpuBars` to `-1` &rarr; Disables Resizable BAR in macOS. Just in case the next user's GPU doesn't support it or it is disabled in BIOS.
 	- Changes `UEFI/Quirks/ResizeGpuBars` to `-1` &rarr; Disables Resizable BAR in UEFI for the same reason.
 	- Changes `Misc/Boot/LauncherOption` to `Disabled` &rarr; To avoid changing boot menu entries on the target system's Firmware/BIOS.
 	- Removes custom entries from `Misc/BlessOverride` &rarr; These overrides have to be created on the target system.

--- a/oc_anonymizer_full.py
+++ b/oc_anonymizer_full.py
@@ -23,6 +23,7 @@ class PlistStripper:
         self.reset_misc_security()
         self.delete_platforminfo_generic()
         self.disable_uefi_apfs()
+        self.disable_resizable_bar()
         self.dump()
 
     def reset_misc_boot(self) -> None:
@@ -69,10 +70,16 @@ class PlistStripper:
         self.plist['PlatformInfo']['Generic']['SystemUUID'] = 'XX-CHANGE_ME-XX'
 
     def disable_uefi_apfs(self) -> None:
-        """ Sets minimal allowed APFS driver date and version to permit any release date and version to load"""
+        """Disables minimal APFS driver version checks, so it can be loaded in macOS Catalina and older. Otherwise, APFS drives won't show in BootPicker."""
 
         self.plist['UEFI']['APFS']['MinDate'] = -1
         self.plist['UEFI']['APFS']['MinVersion'] = -1
+
+    def disable_resizable_bar(self) -> None:
+        """Disables Resizable BAR since you don't know if the next user's GPU suports it!"""
+        
+        self.plist['Booter']['Quirks']['ResizeAppleGpuBars'] = -1
+        self.plist['UEFI']['Quirks']['ResizeGpuBars'] = -1
 
     def dump(self):
         """Saves to a file the newly censored config.plist"""
@@ -83,6 +90,7 @@ class PlistStripper:
                 print(f"Successfully exported anonymized config.plist to {os.path.realpath(f.name)}")
             except (Exception,):
                 print("An error occurred while trying to save the censored config.plist file!")
+
 
 if __name__ == '__main__':
     plist_stripper = PlistStripper()

--- a/oc_anonymizer_lite.py
+++ b/oc_anonymizer_lite.py
@@ -17,6 +17,7 @@ class PlistStripper:
     def __init__(self):
         self.plist = load_plist()
         self.delete_platforminfo_generic()
+        self.reset_misc_security()
         self.disable_uefi_apfs()
         self.dump()
 
@@ -27,6 +28,13 @@ class PlistStripper:
         self.plist['PlatformInfo']['Generic']['ROM'] = b'\x11"3DUf'
         self.plist['PlatformInfo']['Generic']['SystemSerialNumber'] = 'XX-CHANGE_ME-XX'
         self.plist['PlatformInfo']['Generic']['SystemUUID'] = 'XX-CHANGE_ME-XX'
+
+    def reset_misc_security(self) -> None:
+        """Sets
+            -> Misc/Security/ScanPolicy = 0 to allow OpenCore's operating system detection policy
+        """
+
+        self.plist['Misc']['Security']['ScanPolicy'] = 0
 
     def disable_uefi_apfs(self) -> None:
         """Disables minimal APFS driver version checks, so it can be loaded on macOS Catalina and older. Otherwise, APFS drives won't show in BootPicker."""

--- a/oc_anonymizer_lite.py
+++ b/oc_anonymizer_lite.py
@@ -1,0 +1,50 @@
+#!/usr/bin/python3.10
+
+import os
+import plistlib
+import sys
+
+
+def load_plist() -> dict:
+    """ Loads .plist XML like file and returns the opened buffer
+
+    :return: dict-like object of the loaded plist
+    """
+    return plistlib.load(open(sys.argv[1], 'rb'))
+
+
+class PlistStripper:
+    def __init__(self):
+        self.plist = load_plist()
+        self.delete_platforminfo_generic()
+        self.disable_uefi_apfs()
+        self.dump()
+
+    def delete_platforminfo_generic(self) -> None:
+        """Censors several SMBIOS identification fields"""
+
+        self.plist['PlatformInfo']['Generic']['MLB'] = 'XX-CHANGE_ME-XX'
+        self.plist['PlatformInfo']['Generic']['ROM'] = b'\x11"3DUf'
+        self.plist['PlatformInfo']['Generic']['SystemSerialNumber'] = 'XX-CHANGE_ME-XX'
+        self.plist['PlatformInfo']['Generic']['SystemUUID'] = 'XX-CHANGE_ME-XX'
+
+    def disable_uefi_apfs(self) -> None:
+        """Disables minimal APFS driver version checks, so it can be loaded on macOS Catalina and older. Otherwise, APFS drives won't show in BootPicker."""
+
+        self.plist['UEFI']['APFS']['MinDate'] = -1
+        self.plist['UEFI']['APFS']['MinVersion'] = -1
+
+    def dump(self):
+        """Saves the dleaned config.plist to a new file."""
+
+        with open('censored_config.plist', 'wb') as f:
+            try:
+                plistlib.dump(self.plist, f)
+                print(f"Successfully exported anonymized config.plist to {os.path.realpath(f.name)}")
+            except (Exception,):
+                print("An error occurred while trying to save the censored config.plist file!")
+
+
+
+if __name__ == '__main__':
+    plist_stripper = PlistStripper()


### PR DESCRIPTION
**Changes**:

- Splitted the Script in a full and a lite version:
   - "Full" version: remains as was with added rules to disable Resizable BAR
   - "Lite" version: only removes PlatformInfo/Generic (Serials, etc) and changes APFS MinDate and MinVersion to `-1`. For users who think the full version applies too many changes.
- Updated ReadMe file. Simplified instructions.